### PR TITLE
Fix compatibility with PHP 7.4 by removing curly brace

### DIFF
--- a/elysia_cron.module
+++ b/elysia_cron.module
@@ -861,7 +861,7 @@ function elysia_cron_decode_script($text, $apply = TRUE) {
   foreach ($lines as $line) {
     $line = trim($line);
     if (!empty($line)) {
-      if ($line{0} == '#') {
+      if ($line[0] == '#') {
         $lastcomment = trim(substr($line, 1));
 
       }


### PR DESCRIPTION
Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4